### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: PyLock Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nuclear-treestump/pylock-dependency-lockfile/security/code-scanning/1](https://github.com/nuclear-treestump/pylock-dependency-lockfile/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token scopes unless overridden.  
For this workflow, the minimal and appropriate setting is:

- `contents: read`

This preserves existing behavior (checkout and test execution) while preventing unnecessary token write access.  
Edit `.github/workflows/main.yml` near the top-level keys, directly after `on:` (or before `jobs:`), without changing job logic or steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
